### PR TITLE
"generate_catcher" passes "pos" to the "maker"

### DIFF
--- a/lib/syndic_atom.mli
+++ b/lib/syndic_atom.mli
@@ -502,19 +502,17 @@ val aggregate : ?id:id -> ?updated:updated -> ?subtitle:subtitle ->
 
 (**/**)
 
+type person = [ `Email of string | `Name of string | `URI of string ] list
+
 (** Analysis without verification, enjoy ! *)
 val unsafe : Xmlm.input ->
   [> `Feed of
-       [> `Author of
-            [> `Email of string | `Name of string | `URI of string ] list
+       [> `Author of person
        | `Category of
             [> `Label of string | `Scheme of string | `Term of string ] list
-       | `Contributor of
-            [> `Email of string | `Name of string | `URI of string ] list
+       | `Contributor of person
        | `Entry of
-            [> `Author of
-                 [> `Email of string | `Name of string | `URI of string ]
-                   list
+            [> `Author of person
             | `Category of
                  [> `Label of string | `Scheme of string | `Term of string ]
                    list
@@ -522,10 +520,8 @@ val unsafe : Xmlm.input ->
                  [> `Data of Syndic_xml.t list | `SRC of string
                   | `Type of string
                  ] list
-            | `Contributor of
-                 [> `Email of string | `Name of string | `URI of string ]
-                   list
-            | `ID of [> `Data of string ] list
+            | `Contributor of person
+            | `ID of string list
             | `Link of
                  [> `HREF of string
                  | `HREFLang of string
@@ -535,25 +531,21 @@ val unsafe : Xmlm.input ->
                  | `Type of string ]
                    list
             | `Published of [> `Date of string ] list
-            | `Rights of [> `Data of Syndic_xml.t list ]
+            | `Rights of Syndic_xml.t list
             | `Source of
-                 [> `Author of
-                      [> `Email of string | `Name of string | `URI of string ]
-                        list
+                 [> `Author of person
                  | `Category of
                       [> `Label of string
                       | `Scheme of string
                       | `Term of string ]
                         list
-                 | `Contributor of
-                      [> `Email of string | `Name of string | `URI of string ]
-                        list
+                 | `Contributor of person
                  | `Generator of
                       [> `Content of string
                       | `URI of string
                       | `Version of string ]
                         list
-                 | `ID of [> `Data of string ] list
+                 | `ID of string list
                  | `Icon of [> `URI of string ] list
                  | `Link of
                       [> `HREF of string
@@ -564,19 +556,19 @@ val unsafe : Xmlm.input ->
                       | `Type of string ]
                         list
                  | `Logo of [> `URI of string ] list
-                 | `Rights of [> `Data of Syndic_xml.t list ]
-                 | `Subtitle of [> `Data of Syndic_xml.t list ]
-                 | `Title of [> `Data of Syndic_xml.t list ]
+                 | `Rights of Syndic_xml.t list
+                 | `Subtitle of Syndic_xml.t list
+                 | `Title of Syndic_xml.t list
                  | `Updated of [> `Date of string ] list ]
                    list
-            | `Summary of [> `Data of Syndic_xml.t list ]
-            | `Title of [> `Data of Syndic_xml.t  list ]
+            | `Summary of Syndic_xml.t list
+            | `Title of Syndic_xml.t  list
             | `Updated of [> `Date of string ] list ]
               list
        | `Generator of
             [> `Content of string | `URI of string | `Version of string ]
               list
-       | `ID of [> `Data of string ] list
+       | `ID of string list
        | `Icon of [> `URI of string ] list
        | `Link of
             [> `HREF of string
@@ -587,8 +579,8 @@ val unsafe : Xmlm.input ->
             | `Type of string ]
               list
        | `Logo of [> `URI of string ] list
-       | `Rights of [> `Data of Syndic_xml.t list ]
-       | `Subtitle of [> `Data of Syndic_xml.t list ]
-       | `Title of [> `Data of Syndic_xml.t list ]
+       | `Rights of Syndic_xml.t list
+       | `Subtitle of Syndic_xml.t list
+       | `Title of Syndic_xml.t list
        | `Updated of [> `Date of string ] list
        ] list ]

--- a/lib/syndic_atom.mli
+++ b/lib/syndic_atom.mli
@@ -261,7 +261,7 @@ type updated = Syndic_date.t
 
 type source =
   {
-    authors: author * author list;
+    authors: author list;
     categories: category list;
     contributors: author list;
     (** {{: http://tools.ietf.org/html/rfc4287#section-4.2.3}
@@ -311,7 +311,7 @@ val source :
   ?rights:rights ->
   ?subtitle:subtitle ->
   ?updated:updated ->
-  authors:author * author list -> id:id -> title:title -> source
+  authors: author list -> id:id -> title:title -> source
 
 type mime = string
 (** A MIME type that conform to the syntax of a MIME media type, but
@@ -370,7 +370,7 @@ type entry =
     links: link list;
     published: published option;
     rights: rights option;
-    sources: source list;
+    source: source option;
     summary: summary option;
     title: title;
     updated: updated;
@@ -416,7 +416,7 @@ val entry :
   ?links:link list ->
   ?published:published ->
   ?rights:rights ->
-  ?sources:source list ->
+  ?source:source ->
   ?summary:summary ->
   id:id ->
   authors:author * author list ->

--- a/lib/syndic_common.ml
+++ b/lib/syndic_common.ml
@@ -23,7 +23,7 @@ module XML = struct
       | attr :: r -> begin
           match get_producer (get_attr_name attr) attr_producer with
           | Some f when in_namespaces attr ->
-              catch_attr ((f pos (get_attr_value attr)) :: acc) pos r
+              catch_attr ((f (get_attr_value attr)) :: acc) pos r
           | _ -> catch_attr acc pos r end
       | [] -> acc
     in
@@ -40,12 +40,14 @@ module XML = struct
       | [] -> acc
     in
     let generate (pos, tag, datas) =
-      maker (catch_attr (catch_datas [] datas) pos (get_attrs tag))
+      maker ~pos (catch_attr (catch_datas [] datas) pos (get_attrs tag))
     in generate
 
   let dummy_of_xml ~ctor =
     let leaf_producer pos data = ctor data in
-    generate_catcher ~leaf_producer (function [] -> (ctor "") | x :: r -> x)
+    let head ~pos = function [] -> ctor ""
+                           | x :: r -> x in
+    generate_catcher ~leaf_producer head
 end
 
 (* Util *)

--- a/lib/syndic_common.mli
+++ b/lib/syndic_common.mli
@@ -3,10 +3,10 @@ module XML : sig
 
   val generate_catcher :
     ?namespaces:string list ->
-    ?attr_producer:(string * (Xmlm.pos -> string -> 'a)) list ->
+    ?attr_producer:(string * (string -> 'a)) list ->
     ?data_producer:(string * (Xmlm.pos * Xmlm.tag * t list -> 'a)) list ->
     ?leaf_producer:(Xmlm.pos -> string -> 'a) ->
-    ('a list -> 'b) -> Xmlm.pos * Xmlm.tag * t list -> 'b
+    (pos: Xmlm.pos -> 'a list -> 'b) -> Xmlm.pos * Xmlm.tag * t list -> 'b
 
   val dummy_of_xml : ctor:(string -> 'a) ->
     Xmlm.pos * Xmlm.tag * t list -> 'a

--- a/lib/syndic_opml1.ml
+++ b/lib/syndic_opml1.ml
@@ -192,10 +192,9 @@ let head_of_xml =
     "windowBottom", (fun a -> `WindowBottom (window_bottom_of_xml a));
     "windowRight", (fun a -> `WindowRight (window_right_of_xml a))
     ] in
-  fun ((pos, _, _) as xml) ->
   generate_catcher
     ~data_producer
-    (make_head ~pos) xml
+    make_head
 
 let head_of_xml' =
   let data_producer = [
@@ -213,7 +212,7 @@ let head_of_xml' =
   ] in
   generate_catcher
     ~data_producer
-    (fun x -> x)
+    (fun ~pos x -> x)
 
 type outline =
   {
@@ -307,11 +306,11 @@ let make_body ~pos (l : [< body'] list) =
   if List.length l <> 0 then l
   else raise (Error.Error (pos, "Body must contains one <outline> element."))
 
-let body_of_xml ((pos, _, _) as xml) =
+let body_of_xml =
   let data_producer = [
     "outline", (fun a -> (`Outline (outline_of_xml a)))
   ] in
-  generate_catcher ~data_producer (make_body ~pos) xml
+  generate_catcher ~data_producer make_body
 
 let body_of_xml' =
   let data_producer = [
@@ -319,7 +318,7 @@ let body_of_xml' =
   ] in
   generate_catcher
     ~data_producer
-    (fun x -> x)
+    (fun ~pos x -> x)
 
 type opml =
   {
@@ -350,9 +349,9 @@ let make_opml ~pos (l : [< opml'] list) =
                                     element"))
   in { version; head; body}
 
-let opml_of_xml ((pos, _, _) as xml) =
+let opml_of_xml =
   let attr_producer = [
-    "version", (fun _ a -> `Version a)
+    "version", (fun a -> `Version a)
   ] in
   let data_producer = [
     "head", (fun a -> `Head (head_of_xml a));
@@ -361,11 +360,11 @@ let opml_of_xml ((pos, _, _) as xml) =
   generate_catcher
     ~attr_producer
     ~data_producer
-    (make_opml ~pos) xml
+    make_opml
 
 let opml_of_xml' =
   let attr_producer = [
-    "version", (fun _ a -> `Version a)
+    "version", (fun a -> `Version a)
   ] in
   let data_producer = [
     "head", (fun a -> `Head (head_of_xml' a));
@@ -374,7 +373,7 @@ let opml_of_xml' =
   generate_catcher
     ~attr_producer
     ~data_producer
-    (fun x -> x)
+    (fun ~pos x -> x)
 
 let find_opml l =
   find (function XML.Node (_, t, _) -> tag_is t "opml" | _ -> false) l

--- a/lib/syndic_rss1.ml
+++ b/lib/syndic_rss1.ml
@@ -21,9 +21,8 @@ let make_title ~pos (l : [< title' ] list) =
 
 let title_of_xml, title_of_xml' =
   let leaf_producer pos data = `Data data in
-  (fun ((pos, _, _) as xml) ->
-     generate_catcher ~namespaces ~leaf_producer (make_title ~pos) xml),
-  generate_catcher ~namespaces ~leaf_producer (fun x -> x)
+  generate_catcher ~namespaces ~leaf_producer make_title,
+  generate_catcher ~namespaces ~leaf_producer (fun ~pos x -> x)
 
 type name = string
 type name' = [`Data of string]
@@ -39,9 +38,8 @@ let make_name ~pos (l : [< name' ] list) =
 
 let name_of_xml, name_of_xml' =
   let leaf_producer pos data = `Data data in
-  (fun ((pos, _, _) as xml) ->
-     generate_catcher ~namespaces ~leaf_producer (make_name ~pos) xml),
-  generate_catcher ~namespaces ~leaf_producer (fun x -> x)
+  generate_catcher ~namespaces ~leaf_producer make_name,
+  generate_catcher ~namespaces ~leaf_producer (fun ~pos x -> x)
 
 type description = string
 type description' = [ `Data of string ]
@@ -57,9 +55,8 @@ let make_description ~pos (l : [< description' ] list) =
 
 let description_of_xml, description_of_xml' =
   let leaf_producer pos data = `Data data in
-  (fun ((pos, _, _) as xml) ->
-     generate_catcher ~namespaces ~leaf_producer (make_description ~pos) xml),
-  generate_catcher ~namespaces ~leaf_producer (fun x -> x)
+  generate_catcher ~namespaces ~leaf_producer make_description,
+  generate_catcher ~namespaces ~leaf_producer (fun ~pos x -> x)
 
 type channel_image = Uri.t
 type channel_image' = [ `URI of string ]
@@ -75,11 +72,10 @@ let make_channel_image ~pos (l : [< channel_image' ] list) =
 
 let channel_image_of_xml, channel_image_of_xml' =
   let attr_producer = [
-    ("resource", (fun pos a -> `URI a));
+    ("resource", (fun a -> `URI a));
   ] in
-  (fun ((pos, _, _) as xml) ->
-    generate_catcher ~namespaces ~attr_producer (make_channel_image ~pos) xml),
-  generate_catcher ~namespaces ~attr_producer (fun x -> x)
+  generate_catcher ~namespaces ~attr_producer make_channel_image,
+  generate_catcher ~namespaces ~attr_producer (fun ~pos x -> x)
 
 type link = Uri.t
 type link' = [ `URI of string ]
@@ -95,9 +91,8 @@ let make_link ~pos (l : [< link' ] list) =
 
 let link_of_xml, link_of_xml' =
   let leaf_producer pos data = `URI data in
-  (fun ((pos, _, _) as xml) ->
-     generate_catcher ~namespaces ~leaf_producer (make_link ~pos) xml),
-  generate_catcher ~namespaces ~leaf_producer (fun x -> x)
+  generate_catcher ~namespaces ~leaf_producer make_link,
+  generate_catcher ~namespaces ~leaf_producer (fun ~pos x -> x)
 
 type url = Uri.t
 type url' = [ `URI of string ]
@@ -113,9 +108,8 @@ let make_url ~pos (l : [< url' ] list) =
 
 let url_of_xml, url_of_xml' =
   let leaf_producer pos data = `URI data in
-  (fun ((pos, _, _) as xml) ->
-     generate_catcher ~namespaces ~leaf_producer (make_url ~pos) xml),
-  generate_catcher ~namespaces ~leaf_producer (fun x -> x)
+  generate_catcher ~namespaces ~leaf_producer make_url,
+  generate_catcher ~namespaces ~leaf_producer (fun ~pos x -> x)
 
 type li = Uri.t
 type li' = [ `URI of string ]
@@ -131,20 +125,19 @@ let make_li ~pos (l : [< li' ] list) =
 
 let li_of_xml, li_of_xml' =
   let attr_producer = [
-    ("resource", (fun pos a -> `URI a));
+    ("resource", (fun a -> `URI a));
   ] in
-  (fun ((pos, _, _) as xml) ->
-    generate_catcher
+  generate_catcher
     ~namespaces
-    ~attr_producer (make_li ~pos) xml),
+    ~attr_producer make_li,
   generate_catcher
       ~namespaces
-      ~attr_producer (fun x -> x)
+      ~attr_producer (fun ~pos x -> x)
 
 type seq = li list
 type seq' = [ `Li of li ]
 
-let make_seq (l : [< seq' ] list) =
+let make_seq ~pos (l : [< seq' ] list) =
   let li = List.map (function `Li u -> u) l
   in li
 
@@ -162,7 +155,7 @@ let seq_of_xml' =
   ] in
   generate_catcher
       ~namespaces
-      ~data_producer (fun x -> x)
+      ~data_producer (fun ~pos x -> x)
 
 type items = seq
 type items' = [ `Seq of seq ]
@@ -176,13 +169,13 @@ let make_items ~pos (l : [< items' ] list) =
                              <rdf:Seq> element"))
   in li
 
-let items_of_xml ((pos, _, _) as xml)=
+let items_of_xml =
   let data_producer = [
     ("Seq", (fun a -> `Seq (seq_of_xml a)));
   ] in
   generate_catcher
       ~namespaces
-      ~data_producer (make_items ~pos) xml
+      ~data_producer make_items
 
 let items_of_xml' =
   let data_producer = [
@@ -190,7 +183,7 @@ let items_of_xml' =
   ] in
   generate_catcher
       ~namespaces
-      ~data_producer (fun x -> x)
+      ~data_producer (fun ~pos x -> x)
 
 type channel_textinput = Uri.t
 type channel_textinput' = [ `URI of string ]
@@ -206,11 +199,10 @@ let make_textinput ~pos (l : [< channel_textinput' ] list) =
 
 let channel_textinput_of_xml, channel_textinput_of_xml' =
   let attr_producer = [
-    ("resource", (fun pos a -> `URI a));
+    ("resource", (fun a -> `URI a));
   ] in
-  (fun ((pos, _, _) as xml) ->
-     generate_catcher ~namespaces ~attr_producer (make_textinput ~pos) xml),
-  generate_catcher ~namespaces ~attr_producer (fun x -> x)
+  generate_catcher ~namespaces ~attr_producer make_textinput,
+  generate_catcher ~namespaces ~attr_producer (fun ~pos x -> x)
 
 type channel =
   {
@@ -270,7 +262,7 @@ let make_channel ~pos (l : [< channel' ] list) =
     | _ -> None
   in ({ about; title; link; description; image; items; textinput } : channel)
 
-let channel_of_xml ((pos, _, _) as xml) =
+let channel_of_xml =
   let data_producer = [
     ("title", (fun a -> `Title (title_of_xml a)));
     ("link", (fun a -> `Link (link_of_xml a)));
@@ -280,13 +272,13 @@ let channel_of_xml ((pos, _, _) as xml) =
     ("textinput", (fun a -> `TextInput (channel_textinput_of_xml a)));
   ] in
   let attr_producer = [
-    ("about", (fun pos a -> `About a));
+    ("about", (fun a -> `About a));
   ] in
   generate_catcher
     ~namespaces
     ~attr_producer
     ~data_producer
-    (make_channel ~pos) xml
+    make_channel
 
 let channel_of_xml' =
   let data_producer = [
@@ -298,9 +290,9 @@ let channel_of_xml' =
     ("textinput", (fun a -> `TextInput (channel_textinput_of_xml' a)));
   ] in
   let attr_producer = [
-    ("about", (fun pos a -> `About a));
+    ("about", (fun a -> `About a));
   ] in
-  generate_catcher ~namespaces ~attr_producer ~data_producer (fun x -> x)
+  generate_catcher ~namespaces ~attr_producer ~data_producer (fun ~pos x -> x)
 
 type image =
   {
@@ -341,20 +333,20 @@ let make_image ~pos (l : [< image' ] list) =
                              attribute"))
   in ({ about; title; url; link; } : image)
 
-let image_of_xml ((pos, _, _) as xml)=
+let image_of_xml =
   let data_producer = [
     ("title", (fun a -> `Title (title_of_xml a)));
     ("link" , (fun a -> `Link (link_of_xml a)));
     ("url", (fun a -> `URL (url_of_xml a)));
   ] in
   let attr_producer = [
-    ("about", (fun pos a -> `About a));
+    ("about", (fun a -> `About a));
   ] in
   generate_catcher
     ~namespaces
     ~attr_producer
     ~data_producer
-    (make_image ~pos) xml
+    make_image
 
 let image_of_xml' =
   let data_producer = [
@@ -363,9 +355,9 @@ let image_of_xml' =
     ("url", (fun a -> `URL (url_of_xml' a)));
   ] in
   let attr_producer = [
-    ("about", (fun pos a -> `About a));
+    ("about", (fun a -> `About a));
   ] in
-  generate_catcher ~namespaces ~attr_producer ~data_producer (fun x -> x)
+  generate_catcher ~namespaces ~attr_producer ~data_producer (fun ~pos x -> x)
 
 type item =
   {
@@ -405,20 +397,20 @@ let make_item ~pos (l : [< item' ] list) =
                              attribute"))
   in ({ about; title; link; description; } : item)
 
-let item_of_xml ((pos, _, _) as xml)=
+let item_of_xml =
   let data_producer = [
     ("title", (fun a -> `Title (title_of_xml a)));
     ("link", (fun a -> `Link (link_of_xml a)));
     ("description", (fun a -> `Description (description_of_xml a)));
   ] in
   let attr_producer = [
-    ("about", (fun pos a -> `About a));
+    ("about", (fun a -> `About a));
   ] in
   generate_catcher
     ~namespaces
     ~attr_producer
     ~data_producer
-    (make_item ~pos) xml
+    make_item
 
 let item_of_xml' =
   let data_producer = [
@@ -427,9 +419,9 @@ let item_of_xml' =
     ("description", (fun a -> `Description (description_of_xml' a)));
   ] in
   let attr_producer = [
-    ("about", (fun pos a -> `About a));
+    ("about", (fun a -> `About a));
   ] in
-  generate_catcher ~namespaces ~attr_producer ~data_producer (fun x -> x)
+  generate_catcher ~namespaces ~attr_producer ~data_producer (fun ~pos x -> x)
 
 type textinput =
   {
@@ -478,7 +470,7 @@ let make_textinput ~pos (l : [< textinput' ] list) =
                              attribute"))
   in ({ about; title; description; name; link; } : textinput)
 
-let textinput_of_xml ((pos, _, _) as xml)=
+let textinput_of_xml =
   let data_producer = [
     ("title", (fun a -> `Title (title_of_xml a)));
     ("description", (fun a -> `Description (description_of_xml a)));
@@ -486,13 +478,13 @@ let textinput_of_xml ((pos, _, _) as xml)=
     ("link", (fun a -> `Link (link_of_xml a)));
   ] in
   let attr_producer = [
-    ("about", (fun pos a -> `About a))
+    ("about", (fun a -> `About a))
   ] in
   generate_catcher
     ~namespaces
     ~attr_producer
     ~data_producer
-    (make_textinput ~pos) xml
+    make_textinput
 
 let textinput_of_xml' =
   let data_producer = [
@@ -502,9 +494,9 @@ let textinput_of_xml' =
     ("link", (fun a -> `Link (link_of_xml' a)));
   ] in
   let attr_producer = [
-    ("about", (fun pos a -> `About a))
+    ("about", (fun a -> `About a))
   ] in
-  generate_catcher ~namespaces ~attr_producer ~data_producer (fun x -> x)
+  generate_catcher ~namespaces ~attr_producer ~data_producer (fun ~pos x -> x)
 
 type rdf =
   {
@@ -538,7 +530,7 @@ let make_rdf ~pos (l : [< rdf' ] list) =
     List.fold_left (fun acc -> function `Item x -> x :: acc | _ -> acc) [] l
   in ({ channel; image; item; textinput } : rdf)
 
-let rdf_of_xml ((pos, _, _) as xml)=
+let rdf_of_xml =
   let data_producer = [
     ("channel", (fun a -> `Channel (channel_of_xml a)));
     ("image", (fun a -> `Image (image_of_xml a)));
@@ -548,7 +540,7 @@ let rdf_of_xml ((pos, _, _) as xml)=
   generate_catcher
     ~namespaces
     ~data_producer
-    (make_rdf ~pos) xml
+    make_rdf
 
 let rdf_of_xml' =
   let data_producer = [
@@ -557,7 +549,7 @@ let rdf_of_xml' =
     ("item", (fun a -> `Item (item_of_xml' a)));
     ("textinput", (fun a -> `TextInput (textinput_of_xml' a)))
   ] in
-  generate_catcher ~namespaces ~data_producer (fun x -> x)
+  generate_catcher ~namespaces ~data_producer (fun ~pos x -> x)
 
 let parse input =
   match XML.of_xmlm input |> snd with

--- a/lib/syndic_rss1.mli
+++ b/lib/syndic_rss1.mli
@@ -296,32 +296,32 @@ val unsafe : Xmlm.input ->
   [> `RDF of
        [> `Channel of
             [> `About of string
-            | `Description of [> `Data of string ] list
+            | `Description of string list
             | `Image of [> `URI of string ] list
             | `Items of
                  [> `Seq of [> `Li of [> `URI of string ] list ] list ]
                    list
             | `Link of [> `URI of string ] list
             | `TextInput of [> `URI of string ] list
-            | `Title of [> `Data of string ] list ]
+            | `Title of string list ]
               list
        | `Image of
             [> `About of string
             | `Link of [> `URI of string ] list
-            | `Title of [> `Data of string ] list
+            | `Title of string list
             | `URL of [> `URI of string ] list ]
               list
        | `Item of
             [> `About of string
-            | `Description of [> `Data of string ] list
+            | `Description of string list
             | `Link of [> `URI of string ] list
-            | `Title of [> `Data of string ] list ]
+            | `Title of string list ]
               list
        | `TextInput of
             [> `About of string
-            | `Description of [> `Data of string ] list
+            | `Description of string list
             | `Link of [> `URI of string ] list
-            | `Name of [> `Data of string ] list
-            | `Title of [> `Data of string ] list ]
+            | `Name of string list
+            | `Title of string list ]
               list ]
          list ]

--- a/lib/syndic_rss2.ml
+++ b/lib/syndic_rss2.ml
@@ -948,9 +948,10 @@ let entry_of_item (it: item) : Atom.entry =
                  hreflang = None;  title = None;  length = Some e.length }
                :: links
     | None -> links in
-  let sources = match it.source with
+  let source = match it.source with
     | Some s ->
-       [ { Atom.authors = (author, []); (* Best guess *)
+       Some
+         { Atom.authors = [author]; (* Best guess *)
            categories = [];
            contributors = [];
            generator = None;
@@ -963,8 +964,8 @@ let entry_of_item (it: item) : Atom.entry =
            rights = None;
            subtitle = None;
            title = Atom.Text s.data;
-           updated = None } ]
-    | None -> [] in
+           updated = None }
+    | None -> None in
   { Atom.
     authors = (author, []);
     categories;
@@ -974,7 +975,7 @@ let entry_of_item (it: item) : Atom.entry =
     links;
     published = None;
     rights = None;
-    sources;
+    source;
     summary = None;
     title;
     updated = (match it.pubDate with


### PR DESCRIPTION
This streamlines the uses of "generate_catcher" because it was often
wrapped to extract the position of its last XML argument.  Also remove
the "pos" argument to "attr_producer" (never used).