### PR TITLE
Added the Z timezone and some others, to comply with reality and rfc822.

### DIFF
--- a/lib/syndic_date.ml
+++ b/lib/syndic_date.ml
@@ -45,21 +45,25 @@ let of_rfc822 s =
     let span = Ptime.Span.of_int_s ((h * 3600) + (m * 60)) in
     let span = map (fun x -> Some (Ptime.Span.add span x)) (Ptime.Span.of_float_s s) in
     let date_and_time =
-      if z = "" || z = "GMT" || z = "UT" then
+      if z = "" || z = "GMT" || z = "UT" || z = "Z" then
         map2 (fun date span -> Ptime.add_span date span) date span
         |> map (fun x -> Some (Ptime.to_date_time x))
       else
         (* FIXME: this should be made more robust. *)
         let tz_offset_s =
           match z with
-          | "EST" -> (-5) * 3600
-          | "EDT" -> (-4) * 3600
-          | "CST" -> (-6) * 3600
-          | "CDT" -> (-5) * 3600
-          | "MST" -> (-7) * 3600
-          | "MDT" -> (-6) * 3600
-          | "PST" -> (-8) * 3600
-          | "PDT" -> (-7) * 3600
+          | "EST" -> (-5)  * 3600
+          | "EDT" -> (-4)  * 3600
+          | "CST" -> (-6)  * 3600
+          | "CDT" -> (-5)  * 3600
+          | "MST" -> (-7)  * 3600
+          | "MDT" -> (-6)  * 3600
+          | "PST" -> (-8)  * 3600
+          | "PDT" -> (-7)  * 3600
+          | "A"   -> (-1)  * 3600
+          | "M"   -> (-12) * 3600
+          | "N"   -> (1)   * 3600
+          | "Y"   -> (12)  * 3600
           | _ ->
             let zh = sscanf (String.sub z 0 3) "%i" (fun i -> i) in
             let zm = sscanf (String.sub z 3 2) "%i" (fun i -> i) in


### PR DESCRIPTION
Hi!

tl;dr; I added the Z timezone to the date parsing.

A feed I wanted to parse contained the "Z" timezone, which was not supported by the date module. For completeness I added the A, M, N and Y timezone too.
